### PR TITLE
Don't make web requests to the external internet in specs

### DIFF
--- a/spec/test_server.rb
+++ b/spec/test_server.rb
@@ -24,16 +24,6 @@ class TestServer < Sinatra::Base
     path = TestServer.absolute_path("../../html/#{filename}")
     File.read(path)
   end
-
-  # Our test server stores a local version of a programming task page
-  # (which should be more performant and put less unnecessary load on
-  # rosettacode.org). However, this means that relative URLs will then
-  # request resources from our server that it doesn't have, so for all
-  # other requests we will forward them along to rosettacode.org.
-  get '*' do
-    path = request.fullpath
-    redirect to('http://rosettacode.org' + path)
-  end
 end
 
 TestServer.run!


### PR DESCRIPTION
Blocking web requests to the live internet (for other resources from rosettacode.org) does make the tests somewhat less realistic (since I'm only providing the HTML assets to the tests, not any other assets, like CSS or JavaScript). However, fortunately rosettacode.org seems to be sufficiently server-side rendered that this doesn't make a substantive difference to the tests. Bearing these consideration in mind, not making any live web requests just to run specs seems like a worthwhile tradeoff to make.