### PR TITLE
Give native checkboxes a tiny bit of opacity for specs (hack)

### DIFF
--- a/css/languages-selector.css
+++ b/css/languages-selector.css
@@ -97,7 +97,7 @@ button#rcls-toggle-form .rcls-text-hide {
 
 .rcls-checkbox {
   position: absolute;
-  opacity: 0;
+  opacity: 0.01; /* HACK: undetectable to the human eye, but detectable for tests */
 }
 
 .rcls-checkbox, .rcls-checkbox-label {


### PR DESCRIPTION
As a result of the recent bundle update, we have started seeing spec failures of `Unable to find visible css "input#check- all[type=checkbox]"`. I believe that this might be because of a change in Capybara (or a related gem) to no longer acknowledge non-visible elements in specs.

It took waaaayyyy too long for me to realize it, but the checkboxes that the specs were looking for (`input#check- all[type=checkbox]`) were indeed not visible -- although they appeared to be visible when taking screenshots during spec runs. However, what appeared to be checkboxes were actually `::before` elements that I had introduced in 67b201a ("add styling (and adjust tests accordingly)"). The checkboxes are actually hidden (with `opacity: 0`), and the `::before` elements are rendered in their place.

This PR is a bit of a hack, giving the real checkboxes `opacity: 0.01`, which is basically undetectable to the human eye (even if it were detectable, it doesn't really matter, since the real checkboxes are hidden behind the `::before` element checkbox substitutes, but it seems good to be on the safe side in case of issues with some browsers with the positioning of the `::before` elements relative to the real checkboxes, or who knows what else).

This should get specs passing again.