### PR TITLE
Silence RSpec filter announcements (for fit, fdescribe, etc)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'json'
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.silence_filter_announcements = true
 end
 
 Dir[File.expand_path('../support/**/*.rb', __FILE__)].each { |f| require f }


### PR DESCRIPTION
These announcements (which are something like `Running specs with {:focus => true}`) are mildly annoying / not helpful. This RSpec configuration change suppresses them. (Thanks for the option, RSpec! :smile: :+1:)