### PR TITLE
Load extension on rosettacode.org subdomains; scope to /wiki/ paths

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,8 +15,7 @@
   "content_scripts": [
     {
       "matches": [
-        "http://rosettacode.org/*",
-        "https://rosettacode.org/*"
+        "*://*.rosettacode.org/wiki/*"
       ],
       "css": ["css/languages-selector.css"],
       "js": [


### PR DESCRIPTION
I think that Rosetta Code is now being served from `www.rosettacode.org`, rather than from the top-level `rosettacode.org`. However, the URL `matches` in the manifest `matches` did not previously match `www.rosettacode.org`. This change makes it so that `matches` does match `www.rosettacode.org` (and any other `rosettacode.org` subdomain).

Also, since both "Task" and "Draft Task" page paths start with `/wiki/`, let's restrict the extension to only run on such paths.